### PR TITLE
feat: add Tailscale integration and update Docker configuration

### DIFF
--- a/callme_backend/login-auth-api/entrypoint.sh
+++ b/callme_backend/login-auth-api/entrypoint.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+# Função para parar o Tailscale de forma limpa ao sair
+cleanup() {
+    echo "Parando o Tailscale..."
+    # Tenta parar o daemon do tailscaled se ele ainda estiver rodando
+    PID_TAILSCALED=$(pidof tailscaled)
+    if [ -n "$PID_TAILSCALED" ]; then
+        kill "$PID_TAILSCALED"
+    fi
+    echo "Tailscale parado."
+}
+# Executa a função cleanup quando o script receber um sinal de EXIT, INT ou TERM
+trap cleanup EXIT INT TERM
+
+# Inicia o daemon do Tailscale em background
+echo "Iniciando o Tailscale daemon..."
+tailscaled --tun=userspace-networking --socks5-server=localhost:1055 --outbound-http-proxy-listen=localhost:1055 --statedir=/var/lib/tailscale &
+
+# Aguarda um pouco para o daemon iniciar
+sleep 3
+
+# Conecta o Tailscale à sua rede
+echo "Conectando ao Tailscale..."
+tailscale up \
+    --authkey="${TAILSCALE_AUTHKEY}" \
+    --hostname="${TAILSCALE_HOSTNAME:-callme-backend-$(hostname)}" \
+    --accept-routes \
+    --advertise-exit-node="${TAILSCALE_ADVERTISE_EXIT_NODE:-false}"
+
+# Aguarda um pouco para o Tailscale conectar e as rotas serem estabelecidas
+echo "Aguardando conexão do Tailscale..."
+sleep 10 # Pode aumentar se necessário
+
+# Verifica o status do Tailscale (para debug)
+echo "Status do Tailscale:"
+tailscale status || echo "Falha ao obter status do Tailscale (pode não estar totalmente conectado ainda)"
+
+# Lista os IPs do Tailscale (para debug)
+echo "IPs do Tailscale:"
+tailscale ip -4 || echo "Nenhum IP v4 do Tailscale atribuído ainda"
+tailscale ip -6 || echo "Nenhum IP v6 do Tailscale atribuído ainda"
+
+# --- Adicionar Tailscale Netcheck para Diagnóstico ---
+echo "Executando Tailscale netcheck..."
+tailscale netcheck
+# ----------------------------------------------------
+
+# Configura as propriedades de sistema Java para usar o proxy HTTP do Tailscale
+# para acessar o MinIO (e outras URLs HTTP se necessário)
+JAVA_OPTS=""
+# O proxy HTTP está escutando em localhost:1055 dentro do container
+JAVA_OPTS="$JAVA_OPTS -Dhttp.proxyHost=localhost -Dhttp.proxyPort=1055"
+# Se você precisar que localhost e 127.0.0.1 NÃO passem pelo proxy:
+JAVA_OPTS="$JAVA_OPTS -Dhttp.nonProxyHosts=localhost|127.0.0.1"
+# Se você também fosse acessar MinIO via HTTPS, adicionaria:
+# JAVA_OPTS="$JAVA_OPTS -Dhttps.proxyHost=localhost -Dhttps.proxyPort=1055"
+# JAVA_OPTS="$JAVA_OPTS -Dhttps.nonProxyHosts=localhost|127.0.0.1"
+
+echo "Configurações Java (JAVA_OPTS): ${JAVA_OPTS}"
+
+# Finalmente, executa sua aplicação Spring Boot.
+echo "Iniciando a aplicação Spring Boot..."
+cd /app
+exec java ${JAVA_OPTS} -jar app.jar

--- a/callme_frontend/angular-frontend/.dockerignore
+++ b/callme_frontend/angular-frontend/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+README.md
+.env
+.nyc_output
+coverage
+.nyc_output
+.coverage
+.cache
+.DS_Store
+*.log
+dist

--- a/callme_frontend/angular-frontend/Dockerfile
+++ b/callme_frontend/angular-frontend/Dockerfile
@@ -1,12 +1,12 @@
 FROM node:20-alpine AS build
 WORKDIR /app
-COPY package*.json ./
-RUN npm install
 COPY . .
+RUN npm install
 RUN npm run build
 
 FROM nginx:alpine
-RUN rm -rf /usr/share/nginx/html/*
-COPY --from=build /app/dist/angular-frontend /usr/share/nginx/html
-EXPOSE 80
+COPY --from=build /app/dist/angular-frontend/browser /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY mime.types /etc/nginx/mime.types
+EXPOSE 4200
 CMD ["nginx", "-g", "daemon off;"]

--- a/callme_frontend/angular-frontend/angular.json
+++ b/callme_frontend/angular-frontend/angular.json
@@ -39,13 +39,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "600kb",
+                  "maximumError": "700kb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "15kb",
+                  "maximumError": "20kb"
                 }
               ],
               "outputHashing": "all"

--- a/callme_frontend/angular-frontend/mime.types
+++ b/callme_frontend/angular-frontend/mime.types
@@ -1,0 +1,11 @@
+types {
+    text/html                 html htm shtml;
+    text/css                  css;
+    application/javascript    js;
+    application/json          json;
+    image/gif                 gif;
+    image/jpeg                jpeg jpg;
+    application/xml           xml;
+    text/xml                  xml;
+    image/png                 png;
+}

--- a/callme_frontend/angular-frontend/nginx.conf
+++ b/callme_frontend/angular-frontend/nginx.conf
@@ -1,0 +1,25 @@
+events {
+  worker_connections 1024;
+}
+
+http {
+  include      /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+
+  server {
+    listen       4200;
+    server_name  localhost;
+
+    location / {
+      root   /usr/share/nginx/html;
+      index  index.html index.htm;
+      try_files $uri $uri/ /index.html;
+    }
+
+    error_page   500 502 503 504 /50x.html;
+    location = /50x.html {
+      root   /usr/share/nginx/html;
+    }
+  }
+}

--- a/callme_frontend/angular-frontend/src/app/app.routes.ts
+++ b/callme_frontend/angular-frontend/src/app/app.routes.ts
@@ -15,6 +15,11 @@ import {ResetPasswordComponent} from "./pages/reset-password/reset-password.comp
 import {UserlistersComponent} from "./pages/userlisters/userlisters.component";
 export const routes: Routes = [
   {
+    path: '',
+    redirectTo: '/principal',
+    pathMatch: 'full'
+  },
+  {
     path: 'login',
     component: LoginComponent,
   },
@@ -69,10 +74,13 @@ export const routes: Routes = [
     path: 'reset-password',
     component: ResetPasswordComponent
   },
-
   {
     path: 'listar-usuarios',
     component :UserlistersComponent
+  },
+  {
+    path: '**',
+    redirectTo: '/principal'
   }
 
 ];

--- a/callme_frontend/angular-frontend/src/app/pages/usuarios/usuarios.component.scss
+++ b/callme_frontend/angular-frontend/src/app/pages/usuarios/usuarios.component.scss
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@200;300;400;500;600;700;800&display=swap");
-
 * {
   margin: 0;
   padding: 0;

--- a/callme_frontend/angular-frontend/src/index.html
+++ b/callme_frontend/angular-frontend/src/index.html
@@ -9,7 +9,8 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.10.0/css/all.css"
         integrity="sha384-AYmEC3Yw5cVb3ZcuHtOA93w35dYTsvhLPVnYs9eStHfGJvOvKxVfELGroGkvsg+p" crossorigin="anonymous" />
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@200;300;400;500;600;700;800&display=swap" rel="stylesheet">
 </head>
 <body>
   <app-root></app-root>

--- a/callme_frontend/angular-frontend/src/styles.scss
+++ b/callme_frontend/angular-frontend/src/styles.scss
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@200;300;400;500;600;700;800&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700;900&display=swap');
 @import 'ngx-toastr/toastr';
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -57,7 +57,7 @@ services:
       dockerfile: Dockerfile
     container_name: angular_frontend
     ports:
-      - "80:80"
+      - "4200:4200" #
     depends_on:
       - backend
     networks:


### PR DESCRIPTION
Principais alterações:

- **Frontend:**
    - Alterada a porta de exposição e do Nginx de 80 para 4200.
    - Atualizado `compose.yaml` para mapear a porta 4200 para o frontend.
- **Backend:**
    - Restaurado o uso do `entrypoint.sh` para inicialização com Tailscale.
    - Corrigido problema de quebra de linha (CRLF para LF) no `entrypoint.sh` para garantir a execução correta no container Linux.
    - Dockerfile do backend modificado para usar o `entrypoint.sh` corrigido.
- **Documentação:**
    - `README.md` atualizado para refletir a nova porta do frontend, as configurações do Tailscale, e outras melhorias na documentação.